### PR TITLE
Fix buttons background color for 4.1.x

### DIFF
--- a/pinscreenlibrary/src/main/res/drawable/pin_button_normal.xml
+++ b/pinscreenlibrary/src/main/res/drawable/pin_button_normal.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape android:shape="rectangle" xmlns:android="http://schemas.android.com/apk/res/android">
+	<solid android:color="@android:color/transparent" />
     <corners android:radius="2dp"/>
     <stroke android:color="@color/color_primary_dark" android:width="2dp"/>
 </shape>

--- a/pinscreenlibrary/src/main/res/drawable/pin_button_pressed.xml
+++ b/pinscreenlibrary/src/main/res/drawable/pin_button_pressed.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape android:shape="rectangle" xmlns:android="http://schemas.android.com/apk/res/android">
+	<solid android:color="@android:color/transparent" />
     <corners android:radius="2dp"/>
     <stroke android:color="@color/color_primary" android:width="2dp"/>
 </shape>


### PR DESCRIPTION
Pin buttons background color gets drawn solid on 4.1.X  

The fix is based on http://stackoverflow.com/questions/18852709/xml-drawable-having-different-behavior-on-4-3-and-4-1-2